### PR TITLE
Refactor to support terraform-provider-vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,50 @@ Gives you an authenticated vault client (iam/token)
 
 
 # Usage
-go-vault-client supports two modes of authentication `Token` and `Iam`.  First create a `vaultclient.Config` using
+go-vault-client supports three modes of authentication:
+
+* [`AppRole`](https://www.vaultproject.io/docs/auth/approle.html)
+* [`Token`](https://www.vaultproject.io/docs/auth/token.html)
+* [`IAM (AWS)`](https://www.vaultproject.io/docs/auth/aws.html)
+
+##  Configuration
+
+The configuration object used by this client is a superset of the Vault `api.Config` struct.
+
+All configuration which would normally be possible with the Vault client is also possible here, but will not be documented.
+
+Please note: this client no longer configures TLS for you as part of the default configuration.
+
+### Defaults
+
+First create a `vaultclient.Config` using
 
 ```go
 config := vaultclient.NewDefaultConfig()
 ```
 
-If you have the `VAULT_TOKEN` env variable set this will return a config setup for `Token` auth
-If you have the `VAULT_ROLE` env variable set this will return a config setup for `Iam` auth
+The precedence is as follows:
+
+1. If you have the `VAULT_APP_ROLE`, `VAULT_APP_ROLE_ID` and `VAULT_APP_SECRET_ID` env variables set this will return a config setup for `AppRole` auth.
+1. If you have the `VAULT_ROLE` env variable set this will return a config setup for `Iam` auth.
+1. If you have the `VAULT_TOKEN` env variable set this will return a config setup for `Token` auth.
 
 The recommended way to use this client is to set the `VAULT_TOKEN` env variable as part of your test setup and set the `VAULT_ROLE` env
 variable as part of your docker container definition so you will get `Token` auth in your tests and `Iam` auth on AWS.
 
+### Manual
+
+It is also possible to manually configure the client if you do not wish to rely on environment variables.
+
+```go
+clientConfig := vaultclient.BaseConfig()
+```
+
+From here, you may set the `AuthType` and related properties of the configuration manually.
+
+No precedence exists here; only the configured `AuthType` will be used, and a missing `AuthType` will return an error.
+
+## Vault Auth
 
 Create a new vault auth and hang onto the instance.
 ```go

--- a/pkg/vaultclient/app_role_auth_test.go
+++ b/pkg/vaultclient/app_role_auth_test.go
@@ -1,6 +1,7 @@
 package vaultclient
 
 import (
+	"github.com/hashicorp/vault/api"
 	"os"
 	"strings"
 	"testing"
@@ -27,11 +28,16 @@ func TestAppRoleAuth(t *testing.T) {
 	}
 	roleID := resp.Data["role_id"].(string)
 
-	config := &Config{
-		Insecure:        true,
-		AuthType:        AppRole,
-		AppRoleId:       roleID,
-		AppRoleSecretId: secretID,
+	config := BaseConfig()
+	config.AuthType = AppRole
+	config.AppRoleId = roleID
+	config.AppRoleSecretId = secretID
+
+	err = config.ConfigureTLS(&api.TLSConfig{
+		Insecure: true,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	v, err := NewVaultAuth(config)

--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -37,7 +37,7 @@ type appRoleAuth struct {
 }
 
 type Config struct {
-	api.Config
+	*api.Config
 	AuthType        AuthType
 	Token           string
 	IamRole         string
@@ -64,7 +64,7 @@ func BaseConfig() *Config {
 	apiConfig := api.DefaultConfig()
 
 	config := &Config{
-		Config: *apiConfig,
+		Config: apiConfig,
 	}
 
 	return config
@@ -106,7 +106,7 @@ func NewDefaultConfig() *Config {
 }
 
 func NewVaultAuth(cfg *Config) (VaultAuth, error) {
-	c, err := api.NewClient(&cfg.Config)
+	c, err := api.NewClient(cfg.Config)
 	fmt.Printf("CONFIG ADDR: %v %v", cfg.Config.Address, cfg.Address)
 	if err != nil {
 		return nil, err

--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -2,7 +2,6 @@ package vaultclient
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"time"
 
@@ -38,14 +37,13 @@ type appRoleAuth struct {
 }
 
 type Config struct {
+	api.Config
 	AuthType        AuthType
 	Token           string
 	IamRole         string
-	Insecure        bool
 	AppRole         string
 	AppRoleId       string
 	AppRoleSecretId string
-	HttpClient      *http.Client
 }
 
 type Auth struct {
@@ -62,48 +60,57 @@ type VaultAuth interface {
 	VaultClientOrPanic() *api.Client
 }
 
+func BaseConfig() *Config {
+	apiConfig := api.DefaultConfig()
+
+	config := &Config{
+		Config: *apiConfig,
+	}
+
+	return config
+}
+
 func NewDefaultConfig() *Config {
+	config := BaseConfig()
+
 	appRoleName := os.Getenv("VAULT_APP_ROLE")
 	appRoleId := os.Getenv("VAULT_APP_ROLE_ID")
 	appRoleSecretId := os.Getenv("VAULT_APP_SECRET_ID")
-
 	if appRoleId != "" && appRoleSecretId != "" && appRoleName != "" {
-		return &Config{
-			AuthType:        AppRole,
-			AppRole:         appRoleName,
-			AppRoleId:       appRoleId,
-			AppRoleSecretId: appRoleSecretId,
-		}
+		config.AuthType = AppRole
+		config.AppRole = appRoleName
+		config.AppRoleId = appRoleId
+		config.AppRoleSecretId = appRoleSecretId
+
+		return config
 	}
 
 	role := os.Getenv("VAULT_ROLE")
 	if role != "" {
-		return &Config{
-			AuthType: Iam,
-			IamRole:  role,
-		}
+		config.AuthType = Iam
+		config.IamRole = role
+
+		return config
 	}
 
 	token := os.Getenv("VAULT_TOKEN")
 	if token != "" {
-		return &Config{
-			AuthType: Token,
-			Token:    token,
-		}
+		config.AuthType = Token
+		config.Token = token
+
+		return config
 	}
 
-	return nil
+	config.Error = fmt.Errorf("failed to determine auth type from env")
+	return config
 }
 
 func NewVaultAuth(cfg *Config) (VaultAuth, error) {
-	config := api.DefaultConfig()
-	if config.HttpClient != nil {
-		config.HttpClient = cfg.HttpClient
+	if cfg.HttpClient != nil {
+		cfg.HttpClient = cfg.HttpClient
 	}
-	if err := config.ConfigureTLS(&api.TLSConfig{Insecure: cfg.Insecure}); err != nil {
-		return nil, err
-	}
-	c, err := api.NewClient(config)
+
+	c, err := api.NewClient(&cfg.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +197,11 @@ func (t *tokenAuth) VaultClient() (*api.Client, error) {
 }
 
 func (t *tokenAuth) VaultClientOrPanic() *api.Client {
-	return t.client
+	client, err := t.VaultClient()
+	if err != nil {
+		panic(err)
+	}
+	return client
 }
 
 func (a *appRoleAuth) getAuth() (*Auth, error) {

--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -106,11 +106,8 @@ func NewDefaultConfig() *Config {
 }
 
 func NewVaultAuth(cfg *Config) (VaultAuth, error) {
-	if cfg.HttpClient != nil {
-		cfg.HttpClient = cfg.HttpClient
-	}
-
 	c, err := api.NewClient(&cfg.Config)
+	fmt.Printf("CONFIG ADDR: %v %v", cfg.Config.Address, cfg.Address)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -107,7 +107,6 @@ func NewDefaultConfig() *Config {
 
 func NewVaultAuth(cfg *Config) (VaultAuth, error) {
 	c, err := api.NewClient(cfg.Config)
-	fmt.Printf("CONFIG ADDR: %v %v", cfg.Config.Address, cfg.Address)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vaultclient/iam_auth_test.go
+++ b/pkg/vaultclient/iam_auth_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/testutil/retry"
+	"github.com/hashicorp/vault/api"
 )
 
 const (
@@ -37,11 +38,17 @@ func TestIamAuthClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := &Config{
-		AuthType: Iam,
+	config := BaseConfig()
+	config.AuthType = Iam
+	config.IamRole = "test"
+
+	err = config.ConfigureTLS(&api.TLSConfig{
 		Insecure: true,
-		IamRole:  "test",
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+
 	v, err := NewVaultAuth(config)
 	if err != nil {
 		t.Fatal(err)
@@ -77,11 +84,17 @@ func TestExpiredIamTokenGetsRenewed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := &Config{
-		AuthType: Iam,
+	config := BaseConfig()
+	config.AuthType = Iam
+	config.IamRole = "test"
+
+	err = config.ConfigureTLS(&api.TLSConfig{
 		Insecure: true,
-		IamRole:  "test",
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+
 	v, err := NewVaultAuth(config)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/vaultclient/token_auth_test.go
+++ b/pkg/vaultclient/token_auth_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/vault/api"
 )
 
 func TestTokenAuth(t *testing.T) {
@@ -15,11 +17,17 @@ func TestTokenAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := &Config{
-		AuthType: Token,
+	config := BaseConfig()
+	config.AuthType = Token
+	config.Token = configuredVault.rootToken
+
+	err = config.ConfigureTLS(&api.TLSConfig{
 		Insecure: true,
-		Token:    configuredVault.rootToken,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
+
 	v, err := NewVaultAuth(config)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
A fairly significant refactor. Removes opinionated code and embeds the Vault `api.Config` struct into our `vaultclient.Config`.

See the updates to `README.md` for a good high-level overview of the changes. These are breaking changes in any case where the deprecated `Insecure` field was set to `true`.