### PR TITLE
Fix expiration logic

### DIFF
--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -164,7 +164,7 @@ func (v *Auth) IsTokenExpired() bool {
 		return true
 	}
 
-	return v.expiry.Add(expirationWindow).After(time.Now().UTC())
+	return v.expiry.Before(time.Now().Add(expirationWindow).UTC())
 }
 
 func (v *iamAuth) VaultClient() (*api.Client, error) {

--- a/pkg/vaultclient/iam_auth_test.go
+++ b/pkg/vaultclient/iam_auth_test.go
@@ -110,6 +110,9 @@ func TestExpiredIamTokenGetsRenewed(t *testing.T) {
 		}
 	})
 
+	// now wait out the expiration window
+	time.Sleep(expirationWindow + time.Second)
+
 	result, err := v.VaultClientOrPanic().Logical().Read("secret/foo")
 	if err != nil {
 		t.Fatalf("could not read secret using authed client, error: %s", err)


### PR DESCRIPTION
```
old method: v.expiry.Add(expirationWindow).After(time.Now().UTC())
At 00:00:00 - authentication: set v.expiry to time.Now() + ttl(1 minute) = 00:01:00
At 00:02:00 - check is expired using: v.expiry.Add(expirationWindow).After(time.Now().UTC())
Which means 00:01:10 > 00:02:00 = false D:

new method: v.expiry.Before(time.Now().Add(expirationWindow).UTC())
At 00:00:00 - authentication: set v.expiry to time.Now() + ttl(1 minute) = 00:01:00
At 00:02:00 - check is expired using: v.expiry.Before(time.Now().Add(expirationWindow).UTC())
Which means 00:01:00 < 00:02:10 = true :)
```