### PR TITLE
Update the STS endpoint resolver to default as global

### DIFF
--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -25,7 +25,8 @@ const (
 	Token AuthType = iota + 1
 	Iam
 	AppRole
-	envVarAwsRegion = "AWS_REGION"
+	envVarAwsRegion    = "AWS_REGION"
+	envVarStsAwsRegion = "STS_AWS_REGION"
 )
 
 type iamAuth struct {
@@ -175,9 +176,12 @@ func endpointSigningResolver(service, region string, optFns ...func(*endpoints.O
 	if err != nil {
 		return defaultEndpoint, err
 	}
-	defaultEndpoint.SigningRegion = region
 	defaultEndpoint.SigningName = service
-	defaultEndpoint.URL = fmt.Sprintf("https://%s.%v.amazonaws.com", service, region)
+	stsRegion, present := os.LookupEnv(envVarStsAwsRegion)
+	if present {
+		defaultEndpoint.SigningRegion = stsRegion
+		defaultEndpoint.URL = fmt.Sprintf("https://%s.%v.amazonaws.com", service, stsRegion)
+	}
 	return defaultEndpoint, nil
 }
 

--- a/pkg/vaultclient/setup_test.go
+++ b/pkg/vaultclient/setup_test.go
@@ -61,16 +61,14 @@ func newVaultConfiguredForIamAuth(t *testing.T, leaseTtl, maxLeaseTtl string) (*
 		t.Fatal(err)
 	}
 
-	if _, err := client.Logical().Write("auth/aws/config/client", map[string]interface{}{
-		"sts_endpoint": awsTestStsEndpoint,
-		"sts_region":   awsTestRegion,
-	}); err != nil {
-		fmt.Println(err)
-		t.Fatal(err)
-	}
-
 	policy := `
 	path "secret/foo" {
+  		capabilities = ["read", "create"]
+	},
+	path "secret/global" {
+  		capabilities = ["read", "create"]
+	},
+	path "secret/regional" {
   		capabilities = ["read", "create"]
 	}
 `


### PR DESCRIPTION
The STS endpoint resolver needs to be defaulting to global so that it can work in the general case where there no sts regional endpoint configured.

To enable the VPC endpoint to be used, the `STS_AWS_REGION` env var needs to be set with the required region.