### PR TITLE
Add functionality for fallback on login using AWS IAM

### DIFF
--- a/pkg/vaultclient/iam_auth.go
+++ b/pkg/vaultclient/iam_auth.go
@@ -71,7 +71,7 @@ func generateLoginData(stsSession *session.Session) (map[string]interface{}, err
 }
 
 func createFallbackSession(creds *credentials.Credentials, configuredRegion string) (*session.Session, error) {
-	return createSessionWithResolver(configuredRegion, creds, globalEndpointSigningResolver)
+	return createSessionWithResolver(configuredRegion, creds, fallbackEndpointSigningResolver)
 }
 
 func createSession(creds *credentials.Credentials, configuredRegion string) (*session.Session, error) {
@@ -90,7 +90,7 @@ func createSessionWithResolver(configuredRegion string, creds *credentials.Crede
 	return s, err
 }
 
-func globalEndpointSigningResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+func fallbackEndpointSigningResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 	return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
 }
 

--- a/pkg/vaultclient/iam_auth.go
+++ b/pkg/vaultclient/iam_auth.go
@@ -1,0 +1,109 @@
+package vaultclient
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/helper/awsutil"
+	"io/ioutil"
+	"os"
+)
+
+func (v *iamAuth) login(session *session.Session) (*api.Secret, error) {
+	data, err := generateLoginData(session)
+	if err != nil {
+		return nil, err
+	}
+	data["role"] = v.role
+	return v.client.Logical().Write("auth/aws/login", data)
+}
+
+func (v *iamAuth) loginWithFallback(session *session.Session) (*api.Secret, error) {
+	creds := session.Config.Credentials
+	configuredRegion := os.Getenv(envVarAwsRegion)
+	stsSession, err := createSession(creds, configuredRegion)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := v.login(stsSession)
+	if err != nil {
+		stsSession, err = createFallbackSession(creds, configuredRegion)
+		if err != nil {
+			return nil, err
+		}
+		return v.login(stsSession)
+	}
+	return resp, err
+}
+
+func generateLoginData(stsSession *session.Session) (map[string]interface{}, error) {
+	loginData := make(map[string]interface{})
+
+	var params *sts.GetCallerIdentityInput
+	svc := sts.New(stsSession)
+	stsRequest, _ := svc.GetCallerIdentityRequest(params)
+	err := stsRequest.Sign()
+	if err != nil {
+		return nil, err
+	}
+
+	headersJson, err := json.Marshal(stsRequest.HTTPRequest.Header)
+	if err != nil {
+		return nil, err
+	}
+	requestBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
+	if err != nil {
+		return nil, err
+	}
+	loginData["iam_http_request_method"] = stsRequest.HTTPRequest.Method
+	loginData["iam_request_url"] = base64.StdEncoding.EncodeToString([]byte(stsRequest.HTTPRequest.URL.String()))
+	loginData["iam_request_headers"] = base64.StdEncoding.EncodeToString(headersJson)
+	loginData["iam_request_body"] = base64.StdEncoding.EncodeToString(requestBody)
+
+	return loginData, nil
+}
+
+func createFallbackSession(creds *credentials.Credentials, configuredRegion string) (*session.Session, error) {
+	return createSessionWithResolver(configuredRegion, creds, globalEndpointSigningResolver)
+}
+
+func createSession(creds *credentials.Credentials, configuredRegion string) (*session.Session, error) {
+	return createSessionWithResolver(configuredRegion, creds, endpointSigningResolver)
+}
+
+func createSessionWithResolver(configuredRegion string, creds *credentials.Credentials, resolver func(service string, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error)) (*session.Session, error) {
+	region := awsutil.GetOrDefaultRegion(hclog.Default(), configuredRegion)
+	s, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			Credentials:      creds,
+			Region:           &region,
+			EndpointResolver: endpoints.ResolverFunc(resolver),
+		},
+	})
+	return s, err
+}
+
+func globalEndpointSigningResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+}
+
+func endpointSigningResolver(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	defaultEndpoint, err := endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+	if err != nil {
+		return defaultEndpoint, err
+	}
+	defaultEndpoint.SigningName = service
+	stsRegion, present := os.LookupEnv(envVarStsAwsRegion)
+	if present {
+		defaultEndpoint.SigningRegion = stsRegion
+		defaultEndpoint.URL = fmt.Sprintf("https://%s.%v.amazonaws.com", service, stsRegion)
+	}
+	return defaultEndpoint, nil
+}

--- a/pkg/vaultclient/iam_auth_test.go
+++ b/pkg/vaultclient/iam_auth_test.go
@@ -80,6 +80,12 @@ func TestIamAuthWithRegionalEndpointClient(t *testing.T) {
 }
 
 func TestIamAuthWithFallbackEndpointClient(t *testing.T) {
+	/*
+	This test configures the client as if it is expecting to use a regional VPC endpoint for STS however doesn't
+	configure Vault in this way.
+	The expected result is that the attempt to connect should use the STS_AWS_REGION that is set then on failure
+	fallback to the global endpoint.
+	 */
 	configuredVault, destroy := newVaultConfiguredForIamAuth(t, "1h", "1h")
 	if err := os.Setenv(envVarStsAwsRegion, awsTestRegion); err != nil {
 		fmt.Println(err)

--- a/pkg/vaultclient/iam_auth_test.go
+++ b/pkg/vaultclient/iam_auth_test.go
@@ -81,11 +81,11 @@ func TestIamAuthWithRegionalEndpointClient(t *testing.T) {
 
 func TestIamAuthWithFallbackEndpointClient(t *testing.T) {
 	/*
-	This test configures the client as if it is expecting to use a regional VPC endpoint for STS however doesn't
-	configure Vault in this way.
-	The expected result is that the attempt to connect should use the STS_AWS_REGION that is set then on failure
-	fallback to the global endpoint.
-	 */
+		This test configures the client as if it is expecting to use a regional VPC endpoint for STS however doesn't
+		configure Vault in this way.
+		The expected result is that the attempt to connect should use the STS_AWS_REGION that is set then on failure
+		fallback to the global endpoint.
+	*/
 	configuredVault, destroy := newVaultConfiguredForIamAuth(t, "1h", "1h")
 	if err := os.Setenv(envVarStsAwsRegion, awsTestRegion); err != nil {
 		fmt.Println(err)

--- a/pkg/vaultclient/iam_auth_test.go
+++ b/pkg/vaultclient/iam_auth_test.go
@@ -79,6 +79,33 @@ func TestIamAuthWithRegionalEndpointClient(t *testing.T) {
 	testIamAuthClient(t, configuredVault, secretPath)
 }
 
+func TestIamAuthWithFallbackEndpointClient(t *testing.T) {
+	configuredVault, destroy := newVaultConfiguredForIamAuth(t, "1h", "1h")
+	if err := os.Setenv(envVarStsAwsRegion, awsTestRegion); err != nil {
+		fmt.Println(err)
+		t.Fatal(err)
+	}
+	defer destroy()
+
+	// write secret as root
+	secretPath := "secret/fallback"
+	if _, err := configuredVault.rootClient.Logical().Write(secretPath, map[string]interface{}{
+		"foo": "bar",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// write client config
+	if _, err := configuredVault.rootClient.Logical().Write("auth/aws/config/client", map[string]interface{}{
+		"sts_endpoint": "",
+		"sts_region":   "",
+	}); err != nil {
+		fmt.Println(err)
+		t.Fatal(err)
+	}
+	testIamAuthClient(t, configuredVault, secretPath)
+}
+
 func testIamAuthClient(t *testing.T, configuredVault *configuredVault, path string) {
 
 	err := os.Setenv("VAULT_ADDR", configuredVault.address)

--- a/pkg/vaultclient/setup_test.go
+++ b/pkg/vaultclient/setup_test.go
@@ -70,6 +70,9 @@ func newVaultConfiguredForIamAuth(t *testing.T, leaseTtl, maxLeaseTtl string) (*
 	},
 	path "secret/regional" {
   		capabilities = ["read", "create"]
+	},
+	path "secret/fallback" {
+		capabilities = ["read", "create"]
 	}
 `
 	if err := client.Sys().PutPolicy("foowriter", policy); err != nil {


### PR DESCRIPTION
If the `STS_AWS_REGION` env var is present the STS endpoint in signed request will be updated to have a URI of `http://sts.<region>.amazonaws.com`.
For this to work correctly, the `auth/aws/config/client` path needs to be configured with the correct values for `sts_endpoint` and `sts_region`.

This change will allow the client to fall back to trying to login using the default, global endpoint of `https://sts.amazonaws.com` in situations where the `STS_AWS_REGION` has been configured but vault isn't configured.