### PR TITLE
add k8s auth

### DIFF
--- a/pkg/vaultclient/client.go
+++ b/pkg/vaultclient/client.go
@@ -15,6 +15,7 @@ const (
 	Token AuthType = iota + 1
 	Iam
 	AppRole
+	K8s
 	EnvVarAwsRegion    = "AWS_REGION"
 	EnvVarStsAwsRegion = "STS_AWS_REGION"
 )
@@ -45,6 +46,8 @@ type Config struct {
 	AppRole         string
 	AppRoleId       string
 	AppRoleSecretId string
+	K8sRole         string
+	K8sPath         string
 }
 
 type Auth struct {
@@ -90,6 +93,19 @@ func NewDefaultConfig() *Config {
 	if role != "" {
 		config.AuthType = Iam
 		config.IamRole = role
+
+		return config
+	}
+
+	k8sRole := os.Getenv("K8S_ROLE")
+	if k8sRole != "" {
+		config.AuthType = K8s
+		config.K8sRole = k8sRole
+		k8sPath := os.Getenv("K8S_PATH")
+		if k8sPath == "" {
+			k8sPath = fmt.Sprintf("k8s-%s", k8sRole)
+		}
+		config.K8sPath = k8sPath
 
 		return config
 	}

--- a/pkg/vaultclient/k8s_auth.go
+++ b/pkg/vaultclient/k8s_auth.go
@@ -1,0 +1,1 @@
+package vaultclient

--- a/pkg/vaultclient/k8s_auth.go
+++ b/pkg/vaultclient/k8s_auth.go
@@ -46,6 +46,8 @@ func (k *k8sAuth) getAuth() (*Auth, error) {
 }
 
 func (k *k8sAuth) login() (*api.Secret, error) {
+	// this path comes from https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-admission-controller
+	// which is the path that the kubernetes service account controller mounts the jwt token
 	jwt, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {
 		return nil, err

--- a/pkg/vaultclient/k8s_auth.go
+++ b/pkg/vaultclient/k8s_auth.go
@@ -1,1 +1,58 @@
 package vaultclient
+
+import (
+	"fmt"
+	"github.com/hashicorp/vault/api"
+	"io/ioutil"
+	"time"
+)
+
+func (k *k8sAuth) VaultClientOrPanic() *api.Client {
+	client, err := k.VaultClient()
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func (k *k8sAuth) VaultClient() (*api.Client, error) {
+	if !k.auth.IsTokenExpired() {
+		return k.client, nil
+	}
+	var err error
+	k.auth, err = k.getAuth()
+	if err != nil {
+		return nil, err
+	}
+	k.client.SetToken(k.auth.token)
+	return k.client, nil
+}
+
+func (k *k8sAuth) getAuth() (*Auth, error) {
+	resp, err := k.login()
+	if err != nil {
+		return nil, err
+	}
+
+	tokenTtl, err := resp.TokenTTL()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Auth{
+		token:  resp.Auth.ClientToken,
+		expiry: time.Now().UTC().Add(tokenTtl),
+	}, nil
+}
+
+func (k *k8sAuth) login() (*api.Secret, error) {
+	jwt, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return nil, err
+	}
+	data := map[string]interface{}{
+		"jwt":  string(jwt),
+		"role": k.role,
+	}
+	return k.client.Logical().Write(fmt.Sprintf("auth/%s/login", k.path), data)
+}

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -30,6 +30,41 @@ func TestDefaultConfigWhenIamRoleSpecified(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigWhenK8sRoleSpecified(t *testing.T) {
+	defer setEnv("K8S_ROLE", "greatservice")()
+	config := vaultclient.NewDefaultConfig()
+
+	if !strings.EqualFold("greatservice", config.K8sRole) {
+		t.Fatalf("expected k8s role greatservice but got %s", config.K8sRole)
+	}
+
+	if !strings.EqualFold("k8s-greatservice", config.K8sPath) {
+		t.Fatalf("expected k8s path k8s-greatservice but got %s", config.K8sPath)
+	}
+
+	if config.AuthType != vaultclient.K8s {
+		t.Fatalf("expected auth type to be k8s")
+	}
+}
+
+func TestDefaultConfigWhenK8sRoleAndPathSpecified(t *testing.T) {
+	defer setEnv("K8S_ROLE", "myservice")()
+	defer setEnv("K8S_PATH", "kubernetes")()
+	config := vaultclient.NewDefaultConfig()
+
+	if !strings.EqualFold("myservice", config.K8sRole) {
+		t.Fatalf("expected k8s role myservice but got %s", config.K8sRole)
+	}
+
+	if !strings.EqualFold("kubernetes", config.K8sPath) {
+		t.Fatalf("expected k8s path kubernetes but got %s", config.K8sPath)
+	}
+
+	if config.AuthType != vaultclient.K8s {
+		t.Fatalf("expected auth type to be k8s")
+	}
+}
+
 func TestDefaultConfigWhenAppRoleSpecified(t *testing.T) {
 	defer setEnv("VAULT_APP_ROLE", "testrole")()
 	defer setEnv("VAULT_APP_ROLE_ID", "myroleid")()

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,10 @@ module github.com/form3tech-oss/go-vault-client/v4/pkg/test
 go 1.14
 
 // to fix https://github.com/hashicorp/vault/issues/9575
-replace github.com/hashicorp/vault/api => github.com/hashicorp/vault/api v1.0.5-0.20200817232951-d7307fcdfed7
+replace (
+ github.com/hashicorp/vault/api => github.com/hashicorp/vault/api v1.0.5-0.20200817232951-d7307fcdfed7
+ github.com/form3tech-oss/go-vault-client/v4 => ../
+)
 
 require (
 	github.com/aws/aws-sdk-go v1.34.7


### PR DESCRIPTION
Add k8s auth mechanism.  To auth using k8s you have to setup a service account and run your pod as that service account.  You set the env var `K8S_ROLE` to set backend role that is configured for your kubernetes auth backend.  The normal pattern for this would be to have one auth backend per service you wanted to auth with vault.  You can optionally also set `K8S_PATH` which determines the mount point for the k8s backend in vault.  If this is not set then it will default to `k8s-<ROLE_NAME>` as that is the convention we are using at form3.

This code has been tested on a kubernetes cluster.